### PR TITLE
ci: now correctly making release-pypi deploy to pypi once a release is published

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -30,3 +30,4 @@ jobs:
               { "type": "style", "section": "Styles", "hidden": false },
               { "type": "test", "section": "Tests", "hidden": false }
             ]
+          token: ${{ secrets.RELEASEPLEASEPAT }}

--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -3,7 +3,6 @@
 name: Release on PyPI
 
 on:
-  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
…s published