### PR TITLE
ci: re-enabling python versions 3.8, 3.9 and 3.10 in the CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        # python-version: [ 3.8, 3.9, "3.10", 3.11 ]
-        python-version: [ 3.11 ]
+        python-version: [ 3.8, 3.9, "3.10", 3.11 ]
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
as we are getting close to the end of the dev cycle